### PR TITLE
output_check: added path existence/writable permission check (#12)

### DIFF
--- a/extract-playlist.sh
+++ b/extract-playlist.sh
@@ -70,7 +70,12 @@ if [ -z "$localPlaylist" ]; then # define localPlaylist with fallback
 fi
 
 outputchecks() {
-    echo ""
+    if ! [ -d $output_dir ]; then # (not) file exists and is directory
+        echo "-O must be valid and a directory"
+        return 1
+    elif ! [ -w $output_dir ]; then # (not) ...is writable
+        echo "-O you must have permissions to write to directory"
+    fi
 }
 
 btchecks() {


### PR DESCRIPTION
fixes broken -O (output directory) option