### PR TITLE
Merge branch 'main' into test-suite (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,7 @@ set the path to the output
 
 -b [device ID]
 send over bluetooth instead of into an output directory (requires gui intervention)
+
+-i
+(init) go through setup again
 ```


### PR DESCRIPTION
* implemented a config file and interactive setup [untested]

* better portability with /home/sammy

* finish message for setup

* trying to fix -O option not working

* fixed localPlaylist failover

* relocated checks/options and fixed options not working

* restored -i option functionality

* removed finish notification

* improved section comments

* output_check: added path existence/writable permission check (#12)

* v1: minimum viability/stability (for m3u playlists) (#17)

* removes meta in m3u parsing

* protecting against duplicate file chaos

* interactive mode for configuring

* considers 2-layer deep music file directories

* added -i (init) option to README